### PR TITLE
Freetype 2.12.1

### DIFF
--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -5,8 +5,8 @@
 
 import os
 
-TAG = 'version_1'
-HASH = '0d0b1280ba0501ad0a23cf1daa1f86821c722218b59432734d3087a89acd22aabd5c3e5e1269700dcd41e87073046e906060f167c032eb91a3ac8c5808a02783'
+TAG = '2-12-1'
+HASH = '3ef3e47752b7c3cd158c738d7e0194f1c9f97ac85c754b02be6ee0f7999c3c19050f713d1e975f5310a4689337463e7b54450ef62e02c3f09864f4c6b13740d9'
 
 
 def needed(settings):
@@ -14,47 +14,38 @@ def needed(settings):
 
 
 def get(ports, settings, shared):
-  ports.fetch_project('freetype', 'https://github.com/emscripten-ports/FreeType/archive/' + TAG + '.zip', 'FreeType-' + TAG, sha512hash=HASH)
+  ports.fetch_project('freetype', 'https://github.com/freetype/freetype/archive/refs/tags/VER-' + TAG + '.zip', 'FreeType-' + TAG, sha512hash=HASH)
 
   def create(final):
-    source_path = os.path.join(ports.get_dir(), 'freetype', 'FreeType-' + TAG)
+    source_path = os.path.join(ports.get_dir(), 'freetype', 'freetype-VER-' + TAG)
     ports.write_file(os.path.join(source_path, 'include/ftconfig.h'), ftconf_h)
     ports.install_header_dir(os.path.join(source_path, 'include'),
                              target=os.path.join('freetype2'))
+    
+    with open(os.path.join(source_path, 'include', 'freetype', 'config','ftoption.h'), 'a') as ftheader:
+      ftheader.write('#define FT_CONFIG_OPTION_SYSTEM_ZLIB')
 
     # build
     srcs = ['src/autofit/autofit.c',
-            'src/base/ftadvanc.c',
+            'src/base/ftbase.c',
             'src/base/ftbbox.c',
             'src/base/ftbdf.c',
             'src/base/ftbitmap.c',
-            'src/base/ftcalc.c',
             'src/base/ftcid.c',
-            'src/base/ftdbgmem.c',
             'src/base/ftdebug.c',
-            'src/base/ftfntfmt.c',
             'src/base/ftfstype.c',
             'src/base/ftgasp.c',
-            'src/base/ftgloadr.c',
             'src/base/ftglyph.c',
             'src/base/ftgxval.c',
             'src/base/ftinit.c',
-            'src/base/ftlcdfil.c',
             'src/base/ftmm.c',
-            'src/base/ftobjs.c',
             'src/base/ftotval.c',
-            'src/base/ftoutln.c',
             'src/base/ftpatent.c',
             'src/base/ftpfr.c',
-            'src/base/ftrfork.c',
-            'src/base/ftsnames.c',
-            'src/base/ftstream.c',
             'src/base/ftstroke.c',
-            'src/base/ftsynth.c',
             'src/base/ftsystem.c',
-            'src/base/fttrigon.c',
+            'src/base/ftsynth.c',
             'src/base/fttype1.c',
-            'src/base/ftutil.c',
             'src/base/ftwinfnt.c',
             'src/bdf/bdf.c',
             'src/bzip2/ftbzip2.c',
@@ -67,10 +58,12 @@ def get(ports, settings, shared):
             'src/pfr/pfr.c',
             'src/psaux/psaux.c',
             'src/pshinter/pshinter.c',
-            'src/psnames/psmodule.c',
+            'src/psnames/psnames.c',
             'src/raster/raster.c',
+            'src/sdf/sdf.c',
             'src/sfnt/sfnt.c',
             'src/smooth/smooth.c',
+            'src/svg/ftsvg.c',
             'src/truetype/truetype.c',
             'src/type1/type1.c',
             'src/type42/type42.c',
@@ -152,6 +145,10 @@ ftconf_h = r'''/****************************************************************
 
 
 FT_BEGIN_HEADER
+
+/* Requires system zlib */
+#define FT_REQUIRE_ZLIB
+#define FT_CONFIG_OPTION_SYSTEM_ZLIB
 
 
   /*************************************************************************/


### PR DESCRIPTION
This does introduce a dependency on system zilb to resolve a duplicate symbols issue. There's an open issue in freetype to fix this.

https://gitlab.freedesktop.org/freetype/freetype/-/issues/1146